### PR TITLE
Fix un-clickable logout button.

### DIFF
--- a/fragments/auth/template/src/pages/user.svelte
+++ b/fragments/auth/template/src/pages/user.svelte
@@ -6,3 +6,10 @@
 
 <button on:click={logout}>Logout</button>
 <!-- routify:options index=false -->
+
+<style>
+  button {
+    position: relative;
+    z-index: 1;
+  }
+</style>


### PR DESCRIPTION
https://user-images.githubusercontent.com/55504972/111210131-417ff380-85a3-11eb-82b1-8c711836570b.mov

The combo `svite,single-page,auth,autoPreprocess,i18n,markdown,postcss,content,dev` produced the issue above.

Adding `position: relative` and `z-index: 1` to the button did the trick.